### PR TITLE
Add bnb_optimizer argument to finetune_cli.py

### DIFF
--- a/src/f5_tts/train/finetune_cli.py
+++ b/src/f5_tts/train/finetune_cli.py
@@ -63,6 +63,12 @@ def parse_args():
         help="Log inferenced samples per ckpt save steps",
     )
     parser.add_argument("--logger", type=str, default=None, choices=["wandb", "tensorboard"], help="logger")
+    parser.add_argument(
+        "--bnb_optimizer",
+        type=bool,
+        default=False,
+        help="Use 8-bit Adam optimizer from bitsandbytes"
+    )
 
     return parser.parse_args()
 
@@ -147,6 +153,7 @@ def main():
         wandb_resume_id=wandb_resume_id,
         log_samples=args.log_samples,
         last_per_steps=args.last_per_steps,
+        bnb_optimizer=args.bnb_optimizer,
     )
 
     train_dataset = load_dataset(args.dataset_name, tokenizer, mel_spec_kwargs=mel_spec_kwargs)


### PR DESCRIPTION
Add `--bnb_optimizer` argument to CLI and pass it to Trainer initialization.

* Add `--bnb_optimizer` argument to the `parse_args()` function in `src/f5_tts/train/finetune_cli.py`.
* Pass the `bnb_optimizer` argument to the `Trainer` initialization in the `main()` function of `src/f5_tts/train/finetune_cli.py`.

